### PR TITLE
Removed direnv from sets

### DIFF
--- a/etc/portage/sets/eessi-2022.11-linux-aarch64
+++ b/etc/portage/sets/eessi-2022.11-linux-aarch64
@@ -18,4 +18,3 @@ sys-cluster/rdma-core
 sys-process/numactl
 sys-process/htop
 dev-libs/nss
-app-shells/direnv::guru

--- a/etc/portage/sets/eessi-2022.11-linux-ppc64le
+++ b/etc/portage/sets/eessi-2022.11-linux-ppc64le
@@ -18,5 +18,3 @@ sys-cluster/rdma-core
 sys-process/numactl
 sys-process/htop
 dev-libs/nss
-app-shells/direnv::guru
-

--- a/etc/portage/sets/eessi-2022.11-linux-x86_64
+++ b/etc/portage/sets/eessi-2022.11-linux-x86_64
@@ -19,4 +19,3 @@ sys-cluster/rdma-core
 sys-process/numactl
 sys-process/htop
 dev-libs/nss
-app-shells/direnv::guru


### PR DESCRIPTION
Seems it is more complicated than thought initially. Can be added later.